### PR TITLE
fix: update HTML title regex to support attributes and change TypeScript target to ES2018

### DIFF
--- a/src/lib/htmlHelper.ts
+++ b/src/lib/htmlHelper.ts
@@ -243,7 +243,7 @@ const htmlEntityMapping = new Map<string, string>([
 const htmlEntityRegExp = new RegExp(`&(#\\d+|#x[\\da-fA-F]+|${Array.from(htmlEntityMapping.keys()).join('|')});`, 'gi');
 
 export function getTitle(html: string): string|null {
-	const matches = html.match(/(?<=\<title\>).*?(?=\<\/title\>)/si);
+	const matches = html.match(/(?<=\<title[^>]*\>).*?(?=\<\/title\>)/si);
 	if (!matches) {
 		return null;
 	}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
 	"compilerOptions": {
 		"module": "commonjs",
-		"target": "es6",
+		"target": "es2018",
 		"outDir": "out",
 		"lib": [
-			"es6"
+			"es2018"
 		],
 		"sourceMap": true,
 		"rootDir": "src",


### PR DESCRIPTION
fix: update HTML title regex to support attributes and change TypeScript target to ES2018 fix `si` error.

This regular expression `s` flag is only available when targeting 'es2018' or later
![image](https://github.com/user-attachments/assets/19956682-5b31-4fdd-9d44-d8586d3df6ea)
